### PR TITLE
Update trainer_ai.asm

### DIFF
--- a/engine/battle/trainer_ai.asm
+++ b/engine/battle/trainer_ai.asm
@@ -345,7 +345,7 @@ CooltrainerFAI:
 	; The intended 25% chance to consider switching will not apply.
 	; Uncomment the line below to fix this.
 	cp 25 percent + 1
-	; ret nc
+	ret nc ; This line was uncommented to fix
 	ld a, 10
 	call AICheckIfHPBelowFraction
 	jp c, AIUseHyperPotion


### PR DESCRIPTION
Due to a bug in the CoolTrainerFAI routines, the CooltrainerF AI will always switch when their current Pokémon out has between 10-20% health rather than only 25% of the time. This fixes that.