### PR TITLE
Update trainer_ai.asm

### DIFF
--- a/engine/battle/trainer_ai.asm
+++ b/engine/battle/trainer_ai.asm
@@ -387,6 +387,9 @@ KogaAI:
 BlaineAI:
 	cp 25 percent + 1
 	ret nc
+	ld a, 10
+	call AICheckIfHPBelowFraction
+	ret nc
 	jp AIUseSuperPotion
 
 SabrinaAI:


### PR DESCRIPTION
Due to an oversight in Blaine's AI in Red/Blue, the routine that checks if Blaine should use a Super Potion doesn't check for if his Pokémon's health is below 10%, rather uses it 25% of the time regardless of this condition. This was fixed in Yellow using this fix.