### PR TITLE
Update item_effects.asm

### DIFF
--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -474,8 +474,8 @@ ItemUseBall:
 	ld hl, wEnemyBattleStatus3
 	bit TRANSFORMED, [hl]
 	jr z, .notTransformed
-	ld a, DITTO
-	ld [wEnemyMonSpecies2], a
+	; ld a, DITTO ; commented out to fix the above issue
+	; ld [wEnemyMonSpecies2], a ; commented out to fix the above issue
 	jr .skip6
 
 .notTransformed


### PR DESCRIPTION
If a Pokémon is transformed, the Pokémon is assumed to be a Ditto. This is a bug because a wild Pokémon could have used Transform via Mirror Move even though the only wild Pokémon that knows Transform is Ditto.