### PR TITLE
Update core.asm

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -6254,12 +6254,15 @@ LoadEnemyMonData:
 	ld a, [wEnemyMonSpecies2]
 	ld [wd11e], a
 	predef IndexToPokedex
+	call IsGhostBattle
+	jr z, .noMarkSeen
 	ld a, [wd11e]
 	dec a
 	ld c, a
 	ld b, FLAG_SET
 	ld hl, wPokedexSeen
 	predef FlagActionPredef ; mark this mon as seen in the pokedex
+.noMarkSeen
 	ld hl, wEnemyMonLevel
 	ld de, wEnemyMonUnmodifiedLevel
 	ld bc, 1 + NUM_STATS * 2


### PR DESCRIPTION
In a Ghost battle, the Pokémon behind the Ghost will be identified as seen in the Pokédex, 'hinting' at what Pokémon species is behind the Ghost. This fix checks if you are in a Ghost battle and if so, skips over adding the Pokémon species to the Pokédex as seen.