### PR TITLE
Move swap sound is played in the wrong bank

### DIFF
--- a/engine/pokemon/learn_move.asm
+++ b/engine/pokemon/learn_move.asm
@@ -209,8 +209,31 @@ OneTwoAndText:
 	text_far _OneTwoAndText
 	text_pause
 	text_asm
+	push af
+	push bc
+	push de
+	push hl
+	ld a, $1
+	ld [wMuteAudioAndPauseMusic], a
+	call DelayFrame
+	ld a, [wAudioROMBank]
+	push af
+	ld a, BANK(SFX_Swap_1)
+	ld [wAudioROMBank], a
+	ld [wAudioSavedROMBank], a
+	call WaitForSoundToFinish
 	ld a, SFX_SWAP
-	call PlaySoundWaitForCurrent
+	call PlaySound
+	call WaitForSoundToFinish
+	pop af
+	ld [wAudioROMBank], a
+	ld [wAudioSavedROMBank], a
+	xor a
+	ld [wMuteAudioAndPauseMusic], a
+	pop hl
+	pop de
+	pop bc
+	pop af
 	ld hl, PoofText
 	ret
 


### PR DESCRIPTION
Due to an oversight, the move swap sound is played from the wrong bank, playing the wrong sound as a result. This issue was fixed in Yellow.