### PR TITLE
Update item_effects.asm

### DIFF
--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -909,7 +909,10 @@ ItemUseMedicine:
 	ld de, wBattleMonStats
 	ld bc, NUM_STATS * 2
 	call CopyData ; copy party stats to in-battle stat data
-	predef DoubleOrHalveSelectedStats
+	xor a
+	ld [wCalculateWhoseStats], a
+	callfar CalculateModifiedStats
+	callfar ApplyBadgeStatBoosts
 	jp .doneHealing
 .healHP
 	inc hl ; hl = address of current HP


### PR DESCRIPTION
Using an item that cures a Pokémon's status conditions will reset their stats back to their neutral, unmodified values. This is done to remove the stat changes caused by burn and paralysis. However, the modifications from stat changing moves, as well as badge boosts, do not get reapplied. In addition, the number of stat stages does not get updated, which could cause stat changing moves to not behave properly if a stat was at either the +6 or -6 cap.