### PR TITLE
Update trainer_ai.asm

### DIFF
--- a/engine/battle/trainer_ai.asm
+++ b/engine/battle/trainer_ai.asm
@@ -552,6 +552,9 @@ AIPrintItemUseAndUpdateHPBar:
 	xor a
 	ld [wHPBarType], a
 	predef UpdateHPBar2
+	push af
+	farcall DrawEnemyHUDAndHPBar
+	pop af
 	jp DecrementAICount
 
 AISwitchIfEnoughMons:
@@ -636,6 +639,9 @@ AICureStatus:
 	ld [wEnemyMonStatus], a ; clear status of active enemy
 	ld hl, wEnemyBattleStatus3
 	res 0, [hl]
+	push af
+	farcall DrawEnemyHUDAndHPBar
+	pop af
 	ret
 
 AIUseXAccuracy: ; unused


### PR DESCRIPTION
When an AI trainer uses a Full Heal (such as Brock), the status of the opposing pokemon does not update until after the player's turn. When playing with Super Gameboy colors, and the opponent is in yellow or red health, and the AI trainer uses a healing item to restore HP up into a new color (such as back into green health), the color of the HP bar will not update until after the player's turn. The AI's version of using a Full Restore combines both of these observations. Why does this happen? The cause is that, unlike what is done in the core battle engine, the function never gets run when executing the AI item functions.