### PR TITLE
The 'acquired an item' jingle can sometimes be cut off

### DIFF
--- a/engine/events/hidden_items.asm
+++ b/engine/events/hidden_items.asm
@@ -33,9 +33,15 @@ FoundHiddenItemText::
 	ld c, a
 	ld b, FLAG_SET
 	predef FlagActionPredef
+	ld a, [wAudioFadeOutControl]
+	push af
+	xor a
+	ld [wAudioFadeOutControl], a
 	ld a, SFX_GET_ITEM_2
 	call PlaySoundWaitForCurrent
 	call WaitForSoundToFinish
+	pop af
+	ld [wAudioFadeOutControl], a
 	jp TextScriptEnd
 .bagFull
 	call WaitForTextScrollButtonPress ; wait for button press


### PR DESCRIPTION
The 'item acquired' jingle can be cut off if it tries to play and the fadeout counter is not 0.