### PR TITLE
Audio high

### DIFF
--- a/audio/engine_1.asm
+++ b/audio/engine_1.asm
@@ -1186,18 +1186,18 @@ Audio1_InitPitchSlideVars:
 	sub e
 	ld e, a
 
-; Bug. Instead of borrowing from the high byte of the target frequency as it
-; should, it borrows from the high byte of the current frequency instead.
-; This means that the result will be 0x200 greater than it should be if the
+; Previous Bug: Instead of borrowing from the high byte of the target frequency as it
+; should, it borrowed from the high byte of the current frequency instead.
+; This means that the result would be 0x200 greater than it should be if the
 ; low byte of the current frequency is greater than the low byte of the
 ; target frequency.
-	ld a, d
-	sbc b
-	ld d, a
 
+	push af
 	ld hl, wChannelPitchSlideTargetFrequencyHighBytes
 	add hl, bc
+	pop af
 	ld a, [hl]
+	sbc b
 	sub d
 	ld d, a
 	ld b, 0

--- a/audio/engine_2.asm
+++ b/audio/engine_2.asm
@@ -1249,18 +1249,18 @@ Audio2_InitPitchSlideVars:
 	sub e
 	ld e, a
 
-; Bug. Instead of borrowing from the high byte of the target frequency as it
-; should, it borrows from the high byte of the current frequency instead.
-; This means that the result will be 0x200 greater than it should be if the
+; Previous Bug: Instead of borrowing from the high byte of the target frequency as it
+; should, it borrowed from the high byte of the current frequency instead.
+; This means that the result would be 0x200 greater than it should be if the
 ; low byte of the current frequency is greater than the low byte of the
 ; target frequency.
-	ld a, d
-	sbc b
-	ld d, a
 
+	push af
 	ld hl, wChannelPitchSlideTargetFrequencyHighBytes
 	add hl, bc
+	pop af
 	ld a, [hl]
+	sbc b
 	sub d
 	ld d, a
 	ld b, 0

--- a/audio/engine_3.asm
+++ b/audio/engine_3.asm
@@ -1186,18 +1186,18 @@ Audio3_InitPitchSlideVars:
 	sub e
 	ld e, a
 
-; Bug. Instead of borrowing from the high byte of the target frequency as it
-; should, it borrows from the high byte of the current frequency instead.
-; This means that the result will be 0x200 greater than it should be if the
+; Previous Bug: Instead of borrowing from the high byte of the target frequency as it
+; should, it borrowed from the high byte of the current frequency instead.
+; This means that the result would be 0x200 greater than it should be if the
 ; low byte of the current frequency is greater than the low byte of the
 ; target frequency.
-	ld a, d
-	sbc b
-	ld d, a
 
+	push af
 	ld hl, wChannelPitchSlideTargetFrequencyHighBytes
 	add hl, bc
+	pop af
 	ld a, [hl]
+	sbc b
 	sub d
 	ld d, a
 	ld b, 0


### PR DESCRIPTION
Due to an oversight in the audio engine code, when the slide variables are initialized, instead of borrowing from the high byte of the target frequency as it should, it borrows from the high byte of the current frequency instead. This means that the result will be 0x200 greater than it should be if the low byte of the current frequency is greater than the low byte of the target frequency.