### PR TITLE
Delay Oak's Lab Music

### DIFF
--- a/scripts/OaksLab.asm
+++ b/scripts/OaksLab.asm
@@ -119,6 +119,7 @@ OaksLabFollowedOakScript:
 	call UpdateSprites
 	ld hl, wStatusFlags7
 	res BIT_NO_MAP_MUSIC, [hl]
+	call DelayFrame
 	call PlayDefaultMusic
 
 	ld a, SCRIPT_OAKSLAB_OAK_CHOOSE_MON_SPEECH


### PR DESCRIPTION
One of the channels for Prof. Oak's lab music can effectively be stopped before it plays if V-Blank interrupts it. This fix adds a 1-frame delay before playing the music to allow V-Blank to complete first.